### PR TITLE
Add new default page title strategy

### DIFF
--- a/apps/snarbanking-app/src/app/app.config.ts
+++ b/apps/snarbanking-app/src/app/app.config.ts
@@ -1,11 +1,15 @@
 import { ApplicationConfig, isDevMode } from '@angular/core';
 import {
+  TitleStrategy,
   provideRouter,
   withComponentInputBinding,
   withEnabledBlockingInitialNavigation,
 } from '@angular/router';
 import { provideStore } from '@ngrx/store';
-import { shellFeatureRoutes } from '@snarbanking-workspace/shell/feature';
+import {
+  SnarbankingDefaultPageTitleStrategy,
+  shellFeatureRoutes,
+} from '@snarbanking-workspace/shell/feature';
 import {
   provideHttpClient,
   withInterceptorsFromDi,
@@ -32,5 +36,6 @@ export const appConfig: ApplicationConfig = {
     }),
     provideEffects(),
     provideHttpClient(withInterceptorsFromDi()),
+    { provide: TitleStrategy, useClass: SnarbankingDefaultPageTitleStrategy },
   ],
 };

--- a/libs/shell/feature/src/index.ts
+++ b/libs/shell/feature/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/lib.routes';
+export * from './lib/snarbanking-default-page-title.strategy';

--- a/libs/shell/feature/src/lib/snarbanking-default-page-title.strategy.ts
+++ b/libs/shell/feature/src/lib/snarbanking-default-page-title.strategy.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+import { Title } from '@angular/platform-browser';
+import { RouterStateSnapshot, TitleStrategy } from '@angular/router';
+
+@Injectable({ providedIn: 'root' })
+export class SnarbankingDefaultPageTitleStrategy extends TitleStrategy {
+  constructor(private readonly title: Title) {
+    super();
+  }
+
+  override updateTitle(routerState: RouterStateSnapshot) {
+    const title = this.buildTitle(routerState);
+    if (title !== undefined) {
+      this.title.setTitle(`Snar Banking | ${title}`);
+    }
+  }
+}


### PR DESCRIPTION
Add a new default page title strategy that adds the prefix `Snar Banking |`. 

Given the page title is `Expenses`, the final page title after the title strategy is applied will be `Snar Banking | Expenses`.